### PR TITLE
More flexible explicit route declaration and area support

### DIFF
--- a/src/tinyweb.framework.tests/Handlers/HandlerScanner/DefaultHandlerScannerTests.cs
+++ b/src/tinyweb.framework.tests/Handlers/HandlerScanner/DefaultHandlerScannerTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using NUnit.Framework;
+using tinyweb.framework.tests.TestArea;
 
 namespace tinyweb.framework.tests
 {
@@ -15,11 +16,17 @@ namespace tinyweb.framework.tests
             defaultHandlerScanner = new DefaultHandlerScanner();
         }
 
+        [TearDown]
+        public void Teardown()
+        {
+            Tinyweb.Areas.Clear();
+        }
+
         [Test]
         public void FindAll_WhenCalled_FindsAllHandlers()
         {
             var handlers = defaultHandlerScanner.FindAll();
-            Assert.That(handlers.Count(), Is.EqualTo(11));
+            Assert.That(handlers.Count(), Is.EqualTo(15));
         }
 
         [Test]
@@ -118,6 +125,38 @@ namespace tinyweb.framework.tests
         {
             var handlers = defaultHandlerScanner.FindAll();
             Assert.That(handlers.Single(h => h.Type == new ExplicitMethodRouteRootHandler().GetType()).Uri, Is.EqualTo(String.Empty));
+        }
+
+        [Test]
+        public void FindAll_WhenCalled_AreaResourceHandlerIncludesAreaInUri()
+        {
+            Tinyweb.RegisterArea("test", typeof(ResourceHandler).Namespace);
+            var handlers = defaultHandlerScanner.FindAll();
+            Assert.That(handlers.Single(h => h.Type == new ResourceHandler().GetType()).Uri, Is.EqualTo("test/resource"));
+        }
+
+        [Test]
+        public void FindAll_WhenCalled_HandlerWithTheSameNameAsARegisteredAreaInANamespaceMapsToAreaRootUri()
+        {
+            Tinyweb.RegisterArea("test", typeof(TestHandler).Namespace);
+            var handlers = defaultHandlerScanner.FindAll();
+            Assert.That(handlers.Single(h => h.Type == new TestHandler().GetType()).Uri, Is.EqualTo("test"));
+        }
+
+        [Test]
+        public void FindAll_WhenCalled_AreaResourceHandlerWithExplicitRouteIncludesAreaInUri()
+        {
+            Tinyweb.RegisterArea("test", typeof(ExplicitRouteAreaHandler).Namespace);
+            var handlers = defaultHandlerScanner.FindAll();
+            Assert.That(handlers.Single(h => h.Type == new ExplicitRouteAreaHandler().GetType()).Uri, Is.EqualTo("test/foo/bar"));
+        }
+
+        [Test]
+        public void FindAll_WhenCalled_AreaResourceHandlerWithExplicitRouteWithAreaDoesNotPrependAreaAgainInUri()
+        {
+            Tinyweb.RegisterArea("test", typeof(ExplicitRouteWithAreaHandler).Namespace);
+            var handlers = defaultHandlerScanner.FindAll();
+            Assert.That(handlers.Single(h => h.Type == new ExplicitRouteWithAreaHandler().GetType()).Uri, Is.EqualTo("test/foo/baz"));
         }
     }
 }

--- a/src/tinyweb.framework.tests/Handlers/HandlerScanner/DefaultHandlerScannerTests.cs
+++ b/src/tinyweb.framework.tests/Handlers/HandlerScanner/DefaultHandlerScannerTests.cs
@@ -19,7 +19,7 @@ namespace tinyweb.framework.tests
         public void FindAll_WhenCalled_FindsAllHandlers()
         {
             var handlers = defaultHandlerScanner.FindAll();
-            Assert.That(handlers.Count(), Is.EqualTo(9));
+            Assert.That(handlers.Count(), Is.EqualTo(11));
         }
 
         [Test]
@@ -100,10 +100,24 @@ namespace tinyweb.framework.tests
         }
 
         [Test]
-        public void FindAll_WhenCalled_ExplicitRootHandlerHasEmptyUri()
+        public void FindAll_WhenCalled_ExplicitFieldRouteRootHandlerHasEmptyUri()
         {
             var handlers = defaultHandlerScanner.FindAll();
-            Assert.That(handlers.Single(h => h.Type == new ExplicitRootHandler().GetType()).Uri, Is.EqualTo(String.Empty));
+            Assert.That(handlers.Single(h => h.Type == new ExplicitFieldRouteRootHandler().GetType()).Uri, Is.EqualTo(String.Empty));
+        }
+
+        [Test]
+        public void FindAll_WhenCalled_ExplicitPropertyRouteRootHandlerHasEmptyUri()
+        {
+            var handlers = defaultHandlerScanner.FindAll();
+            Assert.That(handlers.Single(h => h.Type == new ExplicitPropertyRouteRootHandler().GetType()).Uri, Is.EqualTo(String.Empty));
+        }
+
+        [Test]
+        public void FindAll_WhenCalled_ExplicitMethodRouteRootHandlerHasEmptyUri()
+        {
+            var handlers = defaultHandlerScanner.FindAll();
+            Assert.That(handlers.Single(h => h.Type == new ExplicitMethodRouteRootHandler().GetType()).Uri, Is.EqualTo(String.Empty));
         }
     }
 }

--- a/src/tinyweb.framework.tests/Init/InitTests.cs
+++ b/src/tinyweb.framework.tests/Init/InitTests.cs
@@ -15,7 +15,7 @@ namespace tinyweb.framework.tests
         [Test]
         public void Initialise_WithSpecificNumberOfHandlers_ReturnsCorrectNumberOfHandlers()
         {
-            Assert.That(Tinyweb.Handlers.Count(), Is.EqualTo(11));
+            Assert.That(Tinyweb.Handlers.Count(), Is.EqualTo(15));
         }
 
         [Test]

--- a/src/tinyweb.framework.tests/Init/InitTests.cs
+++ b/src/tinyweb.framework.tests/Init/InitTests.cs
@@ -15,7 +15,7 @@ namespace tinyweb.framework.tests
         [Test]
         public void Initialise_WithSpecificNumberOfHandlers_ReturnsCorrectNumberOfHandlers()
         {
-            Assert.That(Tinyweb.Handlers.Count(), Is.EqualTo(9));
+            Assert.That(Tinyweb.Handlers.Count(), Is.EqualTo(11));
         }
 
         [Test]

--- a/src/tinyweb.framework.tests/Test Data/Handlers/ExplicitFieldRouteRootHandler.cs
+++ b/src/tinyweb.framework.tests/Test Data/Handlers/ExplicitFieldRouteRootHandler.cs
@@ -1,0 +1,12 @@
+﻿namespace tinyweb.framework.tests
+{
+    public class ExplicitFieldRouteRootHandler
+    {
+        Route route = new Route("/");
+
+        public IResult Get()
+        {
+            return new StringResult("Get");
+        }
+    }
+}

--- a/src/tinyweb.framework.tests/Test Data/Handlers/ExplicitMethodRouteRootHandler.cs
+++ b/src/tinyweb.framework.tests/Test Data/Handlers/ExplicitMethodRouteRootHandler.cs
@@ -1,8 +1,11 @@
 ﻿namespace tinyweb.framework.tests
 {
-    public class ExplicitRootHandler
+    public class ExplicitMethodRouteRootHandler
     {
-        Route route = new Route("/");
+        public Route Route()
+        {
+            return new Route("/");
+        }
 
         public IResult Get()
         {

--- a/src/tinyweb.framework.tests/Test Data/Handlers/ExplicitPropertyRouteRootHandler.cs
+++ b/src/tinyweb.framework.tests/Test Data/Handlers/ExplicitPropertyRouteRootHandler.cs
@@ -1,0 +1,15 @@
+﻿namespace tinyweb.framework.tests
+{
+    public class ExplicitPropertyRouteRootHandler
+    {
+        public Route Route
+        {
+            get { return new Route("/"); }
+        }
+
+        public IResult Get()
+        {
+            return new StringResult("Get");
+        }
+    }
+}

--- a/src/tinyweb.framework.tests/Test Data/Handlers/Test/ExplicitRouteAreaHandler.cs
+++ b/src/tinyweb.framework.tests/Test Data/Handlers/Test/ExplicitRouteAreaHandler.cs
@@ -1,0 +1,15 @@
+﻿namespace tinyweb.framework.tests.TestArea
+{
+    public class ExplicitRouteAreaHandler
+    {
+        public Route Route()
+        {
+            return new Route("foo/bar");
+        }
+        
+        public IResult Get()
+        {
+            return new StringResult("Get");
+        } 
+    }
+}

--- a/src/tinyweb.framework.tests/Test Data/Handlers/Test/ExplicitRouteWithAreaHandler.cs
+++ b/src/tinyweb.framework.tests/Test Data/Handlers/Test/ExplicitRouteWithAreaHandler.cs
@@ -1,0 +1,15 @@
+﻿namespace tinyweb.framework.tests.TestArea
+{
+    public class ExplicitRouteWithAreaHandler
+    {
+        public Route Route()
+        {
+            return new Route("test/foo/baz");
+        }
+        
+        public IResult Get()
+        {
+            return new StringResult("Get");
+        } 
+    }
+}

--- a/src/tinyweb.framework.tests/Test Data/Handlers/Test/ResourceHandler.cs
+++ b/src/tinyweb.framework.tests/Test Data/Handlers/Test/ResourceHandler.cs
@@ -1,0 +1,10 @@
+﻿namespace tinyweb.framework.tests.TestArea
+{
+    public class ResourceHandler
+    {
+        public IResult Get()
+        {
+            return new StringResult("Get");
+        } 
+    }
+}

--- a/src/tinyweb.framework.tests/Test Data/Handlers/Test/TestHandler.cs
+++ b/src/tinyweb.framework.tests/Test Data/Handlers/Test/TestHandler.cs
@@ -1,0 +1,10 @@
+﻿namespace tinyweb.framework.tests.TestArea
+{
+    public class TestHandler
+    {
+        public IResult Get()
+        {
+            return new StringResult("Get");
+        } 
+    }
+}

--- a/src/tinyweb.framework.tests/tinyweb.framework.tests.csproj
+++ b/src/tinyweb.framework.tests/tinyweb.framework.tests.csproj
@@ -109,7 +109,9 @@
     <Compile Include="Test Data\Filters\NonPirorityFilter.cs" />
     <Compile Include="Test Data\Filters\InvalidFilter.cs" />
     <Compile Include="Test Data\Handlers\BeforeAfterHandler.cs" />
-    <Compile Include="Test Data\Handlers\ExplicitRootHandler.cs" />
+    <Compile Include="Test Data\Handlers\ExplicitMethodRouteRootHandler.cs" />
+    <Compile Include="Test Data\Handlers\ExplicitPropertyRouteRootHandler.cs" />
+    <Compile Include="Test Data\Handlers\ExplicitFieldRouteRootHandler.cs" />
     <Compile Include="Test Data\Handlers\RootHandler.cs" />
     <Compile Include="TestHelpers\ContextHelpers.cs" />
     <Compile Include="TestHelpers\ObjectHelper.cs" />

--- a/src/tinyweb.framework.tests/tinyweb.framework.tests.csproj
+++ b/src/tinyweb.framework.tests/tinyweb.framework.tests.csproj
@@ -113,6 +113,10 @@
     <Compile Include="Test Data\Handlers\ExplicitPropertyRouteRootHandler.cs" />
     <Compile Include="Test Data\Handlers\ExplicitFieldRouteRootHandler.cs" />
     <Compile Include="Test Data\Handlers\RootHandler.cs" />
+    <Compile Include="Test Data\Handlers\Test\ExplicitRouteWithAreaHandler.cs" />
+    <Compile Include="Test Data\Handlers\Test\ExplicitRouteAreaHandler.cs" />
+    <Compile Include="Test Data\Handlers\Test\ResourceHandler.cs" />
+    <Compile Include="Test Data\Handlers\Test\TestHandler.cs" />
     <Compile Include="TestHelpers\ContextHelpers.cs" />
     <Compile Include="TestHelpers\ObjectHelper.cs" />
     <Compile Include="Init\InitWithRegistriesTests.cs" />

--- a/src/tinyweb.framework/Init/Tinyweb.cs
+++ b/src/tinyweb.framework/Init/Tinyweb.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -11,11 +12,17 @@ namespace tinyweb.framework
 {
     public static class Tinyweb
     {
+        public static IDictionary<string, string> Areas { get; set; } 
         public static IEnumerable<HandlerData> Handlers { get; set; }
         public static IEnumerable<FilterData> Filters { get; set; }
 
         public static Action<Exception, RequestContext, HandlerData> OnError;
         public static bool AllowFormatExtensions { get; set; }
+
+        static Tinyweb()
+        {
+            Areas = new Dictionary<string, string>();
+        }
 
         public static int Init(params Registry[] registries)
         {
@@ -26,6 +33,11 @@ namespace tinyweb.framework
             Handlers.ForEach(addRoute);
 
             return Handlers.Count();
+        }
+
+        public static void RegisterArea(string area, string areaNamespace)
+        {
+            Areas.Add(areaNamespace, area);
         }
 
         public static string WhatHaveIGot()


### PR DESCRIPTION
Your recent commit to allow public route fields sparked an idea on something that was bugging me in terms of testability. I made a quick change to allow fields, properties, and methods to define routes - just have a member or method named "route" (upper or lower case) and it will use that.

Secondly, I love the convention based routing based on type name - excellent idea - but I wanted to be able to control it for those parts of the application where there are lots of resources under a given area - say "administration" or something similar, so instead of having to do AdministrationClientsHandler I wanted to say "every handler in this namespace gets a route that starts with administration/". A short while later I had a rough implementation working:

Tinyweb.RegisterArea("administration", typeof(AdministrationHandler).Namespace);
Tinyweb.Init(...);

Like I said it's rough, and based on global state (tracking a static dictionary) but it works and has coverage. If you have any ideas I'd love to hear them.
