### PR TITLE
Only cache views when debugging is disabled

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -64,6 +64,8 @@ Links to blogs and other resources about Tinyweb:
 
 [Micro Web Frameworks in .NET 101: Tinyweb](http://yobriefca.se/blog/2011/07/18/micro-web-frameworks-101-tinyweb/)
 
+[Tinyweb and HttpListener](http://uoe.dk/blog/2011/08/09/TinywebAndHttpListener.aspx)
+
 ## Applications
 
 The following full applications have been built with Tinyweb:
@@ -83,6 +85,8 @@ The easiest way to get started with Tinyweb is to [NuGet it](http://nuget.org/Li
 You can see the live build status (and grab the binary releases) from the [build server.](http://ci.thunder.invalidcast.com)
 
 ## Versions
+
+2.2.4 Area support for a less duplicative way of defining multiple handlers using the handler namespace (thanks Matt Burton) and bootstrap performance enhancements
 
 2.2.3 Made all result types testable by making their input public, allowing test inspection before rendering
 

--- a/readme.md
+++ b/readme.md
@@ -118,6 +118,8 @@ You can see the live build status (and grab the binary releases) from the [build
 
 Many thanks to the following people who have contributed to Tinyweb:
 
+* [Matt Burton](https://github.com/mattburton)
+
 * [Ben Dornis](https://github.com/Buildstarted)
 
 * [Tom Bell](https://github.com/tombell)

--- a/src/Tinyweb.nuspec
+++ b/src/Tinyweb.nuspec
@@ -2,7 +2,7 @@
 <package xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <metadata xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
     <id>Tinyweb</id>
-    <version>2.2.3</version>
+    <version>2.2.4</version>
     <title>Tinyweb Web Framework</title>
     <authors>Martin Rue</authors>
     <owners>Martin Rue</owners>

--- a/src/tinyweb.framework.tests/Filters/FilterScanner/DefaultFilterScannerTests.cs
+++ b/src/tinyweb.framework.tests/Filters/FilterScanner/DefaultFilterScannerTests.cs
@@ -8,24 +8,26 @@ namespace tinyweb.framework.tests
     public class DefaultFilterScannerTests
     {
         IFilterScanner defaultFilterScanner;
+        ScanResult scanResult;
 
         [SetUp]
         public void Setup()
         {
             defaultFilterScanner = new DefaultFilterScanner();
+            scanResult = AssemblyScanner.FindHandlersAndFilters(HandlerScanner.Current.GetSearcher(), FilterScanner.Current.GetSearcher());
         }
 
         [Test]
         public void FindAll_WhenCalled_FindsAllFilters()
         {
-            var filters = defaultFilterScanner.FindAll();
+            var filters = defaultFilterScanner.FindAll(scanResult.Filters);
             Assert.That(filters.Count(), Is.EqualTo(7));
         }
 
         [Test]
         public void FindAll_WhenCalled_CorrectlyMarksAfterFilter()
         {
-            var filter = defaultFilterScanner.FindAll().Single(f => f.Type == typeof(AfterFilter));
+            var filter = defaultFilterScanner.FindAll(scanResult.Filters).Single(f => f.Type == typeof(AfterFilter));
             Assert.That(filter.BeforeFilter, Is.False);
             Assert.That(filter.AfterFilter, Is.True);
         }
@@ -33,7 +35,7 @@ namespace tinyweb.framework.tests
         [Test]
         public void FindAll_WhenCalled_CorrectlyMarksBeforeFilter()
         {
-            var filter = defaultFilterScanner.FindAll().Single(f => f.Type == typeof(BeforeFilter));
+            var filter = defaultFilterScanner.FindAll(scanResult.Filters).Single(f => f.Type == typeof(BeforeFilter));
             Assert.That(filter.BeforeFilter, Is.True);
             Assert.That(filter.AfterFilter, Is.False);
         }
@@ -41,7 +43,7 @@ namespace tinyweb.framework.tests
         [Test]
         public void FindAll_WhenCalled_CorrectlyMarksBeforeAndAfterFilter()
         {
-            var filter = defaultFilterScanner.FindAll().Single(f => f.Type == typeof(BeforeAndAfterFilter));
+            var filter = defaultFilterScanner.FindAll(scanResult.Filters).Single(f => f.Type == typeof(BeforeAndAfterFilter));
             Assert.That(filter.BeforeFilter, Is.True);
             Assert.That(filter.AfterFilter, Is.True);
         }
@@ -49,7 +51,7 @@ namespace tinyweb.framework.tests
         [Test]
         public void FindAll_WhenCalled_IncludesExpectedFilters()
         {
-            var filters = defaultFilterScanner.FindAll();
+            var filters = defaultFilterScanner.FindAll(scanResult.Filters);
             Assert.That(filters.Any(f => f.Type == typeof(BeforeFilter)));
             Assert.That(filters.Any(f => f.Type == typeof(BeforeAndAfterFilter)));
             Assert.That(filters.Any(f => f.Type == typeof(AfterFilter)));
@@ -59,7 +61,7 @@ namespace tinyweb.framework.tests
         [Test]
         public void FindAll_WhenCalled_FindsCorrectFilterPriorities()
         {
-            var filters = defaultFilterScanner.FindAll();
+            var filters = defaultFilterScanner.FindAll(scanResult.Filters);
             Assert.That(filters.Single(f => f.Type == typeof(BeforeFilter)).Priority, Is.EqualTo(3));
             Assert.That(filters.Single(f => f.Type == typeof(BeforeAndAfterFilter)).Priority, Is.EqualTo(2));
             Assert.That(filters.Single(f => f.Type == typeof(AfterFilter)).Priority, Is.EqualTo(1));

--- a/src/tinyweb.framework.tests/Handlers/HandlerFactory/DefaultHandlerFactoryTests.cs
+++ b/src/tinyweb.framework.tests/Handlers/HandlerFactory/DefaultHandlerFactoryTests.cs
@@ -11,7 +11,7 @@ namespace tinyweb.framework.tests
         [SetUp]
         public void Setup()
         {
-            defaultHandlerFactory = new DefaultHandlerFactory();
+            defaultHandlerFactory = new StructureMapHandlerFactory();
         }
 
         [Test]

--- a/src/tinyweb.framework.tests/Handlers/HandlerFactory/HandlerFactoryTests.cs
+++ b/src/tinyweb.framework.tests/Handlers/HandlerFactory/HandlerFactoryTests.cs
@@ -8,13 +8,13 @@ namespace tinyweb.framework.tests
         [TearDown]
         public void TearDown()
         {
-            HandlerFactory.SetHandlerFactory(new DefaultHandlerFactory());
+            HandlerFactory.SetHandlerFactory(new StructureMapHandlerFactory());
         }
 
         [Test]
         public void Current_WhenRequested_ReturnsDefaultHandlerFactory()
         {
-            Assert.IsInstanceOf<DefaultHandlerFactory>(HandlerFactory.Current);
+            Assert.IsInstanceOf<ActivatorHandlerFactory>(HandlerFactory.Current);
         }
 
         [Test]

--- a/src/tinyweb.framework.tests/Handlers/HandlerScanner/DefaultHandlerScannerTests.cs
+++ b/src/tinyweb.framework.tests/Handlers/HandlerScanner/DefaultHandlerScannerTests.cs
@@ -9,11 +9,13 @@ namespace tinyweb.framework.tests
     public class DefaultHandlerScannerTests
     {
         IHandlerScanner defaultHandlerScanner;
+        ScanResult scanResult;
 
         [SetUp]
         public void Setup()
         {
             defaultHandlerScanner = new DefaultHandlerScanner();
+            scanResult = AssemblyScanner.FindHandlersAndFilters(HandlerScanner.Current.GetSearcher(), FilterScanner.Current.GetSearcher());
         }
 
         [TearDown]
@@ -25,105 +27,105 @@ namespace tinyweb.framework.tests
         [Test]
         public void FindAll_WhenCalled_FindsAllHandlers()
         {
-            var handlers = defaultHandlerScanner.FindAll();
+            var handlers = defaultHandlerScanner.FindAll(scanResult.Handlers);
             Assert.That(handlers.Count(), Is.EqualTo(15));
         }
 
         [Test]
         public void FindAll_WhenCalled_FirstHandlerTypeIsResource1Handler()
         {
-            var handlers = defaultHandlerScanner.FindAll();
+            var handlers = defaultHandlerScanner.FindAll(scanResult.Handlers);
             Assert.That(handlers.Any(h => h.Type == new Resource1Handler().GetType()));
         }
 
         [Test]
         public void FindAll_WhenCalled_FirstHandlerUriIsCorrect()
         {
-            var handlers = defaultHandlerScanner.FindAll();
+            var handlers = defaultHandlerScanner.FindAll(scanResult.Handlers);
             Assert.That(handlers.Single(h => h.Type == new Resource1Handler().GetType()).Uri == "resource1");
         }
 
         [Test]
         public void FindAll_WhenCalled_SecondHandlerTypeIsResource2Handler()
         {
-            var handlers = defaultHandlerScanner.FindAll();
+            var handlers = defaultHandlerScanner.FindAll(scanResult.Handlers);
             Assert.That(handlers.Any(h => h.Type == new Resource2Handler().GetType()));
         }
 
         [Test]
         public void FindAll_WhenCalled_SecondHandlerUriIsCorrect()
         {
-            var handlers = defaultHandlerScanner.FindAll();
+            var handlers = defaultHandlerScanner.FindAll(scanResult.Handlers);
             Assert.That(handlers.Single(h => h.Type == new Resource2Handler().GetType()).Uri == "resource2");
         }
 
         [Test]
         public void FindAll_WhenCalled_ThirdHandlerTypeIsResource3Handler()
         {
-            var handlers = defaultHandlerScanner.FindAll();
+            var handlers = defaultHandlerScanner.FindAll(scanResult.Handlers);
             Assert.That(handlers.Any(h => h.Type == new Resource3Handler().GetType()));
         }
 
         [Test]
         public void FindAll_WhenCalled_ThirdHandlerUriIsCorrect()
         {
-            var handlers = defaultHandlerScanner.FindAll();
+            var handlers = defaultHandlerScanner.FindAll(scanResult.Handlers);
             Assert.That(handlers.Single(h => h.Type == new Resource3Handler().GetType()).Uri == "resource3");
         }
 
         [Test]
         public void FindAll_WhenCalled_FourthHandlerTypeIsConventionHandler()
         {
-            var handlers = defaultHandlerScanner.FindAll();
+            var handlers = defaultHandlerScanner.FindAll(scanResult.Handlers);
             Assert.That(handlers.Any(h => h.Type == new ConventionHandler().GetType()));
         }
 
         [Test]
         public void FindAll_WhenCalled_FourthHandlerUriIsCorrect()
         {
-            var handlers = defaultHandlerScanner.FindAll();
+            var handlers = defaultHandlerScanner.FindAll(scanResult.Handlers);
             Assert.That(handlers.Single(h => h.Type == new ConventionHandler().GetType()).Uri == "convention");
         }
 
         [Test]
         public void FindAll_WhenCalled_PascalConventionHandlerHasBeenLocated()
         {
-            var handlers = defaultHandlerScanner.FindAll();
+            var handlers = defaultHandlerScanner.FindAll(scanResult.Handlers);
             Assert.That(handlers.Any(h => h.Type == new PascalConventionHandler().GetType()));
         }
 
         [Test]
         public void FindAll_WhenCalled_PascalConventionHandlerHasCorrectUri()
         {
-            var handlers = defaultHandlerScanner.FindAll();
+            var handlers = defaultHandlerScanner.FindAll(scanResult.Handlers);
             Assert.That(handlers.Single(h => h.Type == new PascalConventionHandler().GetType()).Uri, Is.EqualTo("pascal/convention"));
         }
 
         [Test]
         public void FindAll_WhenCalled_RootHandlerHasEmptyUri()
         {
-            var handlers = defaultHandlerScanner.FindAll();
+            var handlers = defaultHandlerScanner.FindAll(scanResult.Handlers);
             Assert.That(handlers.Single(h => h.Type == new RootHandler().GetType()).Uri, Is.EqualTo(String.Empty));
         }
 
         [Test]
         public void FindAll_WhenCalled_ExplicitFieldRouteRootHandlerHasEmptyUri()
         {
-            var handlers = defaultHandlerScanner.FindAll();
+            var handlers = defaultHandlerScanner.FindAll(scanResult.Handlers);
             Assert.That(handlers.Single(h => h.Type == new ExplicitFieldRouteRootHandler().GetType()).Uri, Is.EqualTo(String.Empty));
         }
 
         [Test]
         public void FindAll_WhenCalled_ExplicitPropertyRouteRootHandlerHasEmptyUri()
         {
-            var handlers = defaultHandlerScanner.FindAll();
+            var handlers = defaultHandlerScanner.FindAll(scanResult.Handlers);
             Assert.That(handlers.Single(h => h.Type == new ExplicitPropertyRouteRootHandler().GetType()).Uri, Is.EqualTo(String.Empty));
         }
 
         [Test]
         public void FindAll_WhenCalled_ExplicitMethodRouteRootHandlerHasEmptyUri()
         {
-            var handlers = defaultHandlerScanner.FindAll();
+            var handlers = defaultHandlerScanner.FindAll(scanResult.Handlers);
             Assert.That(handlers.Single(h => h.Type == new ExplicitMethodRouteRootHandler().GetType()).Uri, Is.EqualTo(String.Empty));
         }
 
@@ -131,7 +133,7 @@ namespace tinyweb.framework.tests
         public void FindAll_WhenCalled_AreaResourceHandlerIncludesAreaInUri()
         {
             Tinyweb.RegisterArea("test", typeof(ResourceHandler).Namespace);
-            var handlers = defaultHandlerScanner.FindAll();
+            var handlers = defaultHandlerScanner.FindAll(scanResult.Handlers);
             Assert.That(handlers.Single(h => h.Type == new ResourceHandler().GetType()).Uri, Is.EqualTo("test/resource"));
         }
 
@@ -139,7 +141,7 @@ namespace tinyweb.framework.tests
         public void FindAll_WhenCalled_HandlerWithTheSameNameAsARegisteredAreaInANamespaceMapsToAreaRootUri()
         {
             Tinyweb.RegisterArea("test", typeof(TestHandler).Namespace);
-            var handlers = defaultHandlerScanner.FindAll();
+            var handlers = defaultHandlerScanner.FindAll(scanResult.Handlers);
             Assert.That(handlers.Single(h => h.Type == new TestHandler().GetType()).Uri, Is.EqualTo("test"));
         }
 
@@ -147,7 +149,7 @@ namespace tinyweb.framework.tests
         public void FindAll_WhenCalled_AreaResourceHandlerWithExplicitRouteIncludesAreaInUri()
         {
             Tinyweb.RegisterArea("test", typeof(ExplicitRouteAreaHandler).Namespace);
-            var handlers = defaultHandlerScanner.FindAll();
+            var handlers = defaultHandlerScanner.FindAll(scanResult.Handlers);
             Assert.That(handlers.Single(h => h.Type == new ExplicitRouteAreaHandler().GetType()).Uri, Is.EqualTo("test/foo/bar"));
         }
 
@@ -155,7 +157,7 @@ namespace tinyweb.framework.tests
         public void FindAll_WhenCalled_AreaResourceHandlerWithExplicitRouteWithAreaDoesNotPrependAreaAgainInUri()
         {
             Tinyweb.RegisterArea("test", typeof(ExplicitRouteWithAreaHandler).Namespace);
-            var handlers = defaultHandlerScanner.FindAll();
+            var handlers = defaultHandlerScanner.FindAll(scanResult.Handlers);
             Assert.That(handlers.Single(h => h.Type == new ExplicitRouteWithAreaHandler().GetType()).Uri, Is.EqualTo("test/foo/baz"));
         }
     }

--- a/src/tinyweb.framework.tests/Test Data/FilterScanners/CustomFilterScanner.cs
+++ b/src/tinyweb.framework.tests/Test Data/FilterScanners/CustomFilterScanner.cs
@@ -5,7 +5,12 @@ namespace tinyweb.framework.tests
 {
     public class CustomFilterScanner : IFilterScanner
     {
-        public IEnumerable<FilterData> FindAll()
+        public IEnumerable<FilterData> FindAll(IEnumerable<Type> types)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Func<Type, bool> GetSearcher()
         {
             throw new NotImplementedException();
         }

--- a/src/tinyweb.framework.tests/Test Data/HandlerScanners/CustomHandlerScanner.cs
+++ b/src/tinyweb.framework.tests/Test Data/HandlerScanners/CustomHandlerScanner.cs
@@ -5,7 +5,12 @@ namespace tinyweb.framework.tests
 {
     public class CustomHandlerScanner : IHandlerScanner
     {
-        public IEnumerable<HandlerData> FindAll()
+        public IEnumerable<HandlerData> FindAll(IEnumerable<Type> types)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Func<Type, bool> GetSearcher()
         {
             throw new NotImplementedException();
         }

--- a/src/tinyweb.framework/AssemblyScanner/AssemblyScanner.cs
+++ b/src/tinyweb.framework/AssemblyScanner/AssemblyScanner.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace tinyweb.framework
+{
+    public class AssemblyScanner
+    {
+        public static ScanResult FindHandlersAndFilters(Func<Type, bool> isValidHandler, Func<Type, bool> isValidFilter)
+        {
+            var handlers = new List<Type>();
+            var filters = new List<Type>();
+
+            foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
+            {
+                if (assembly.GlobalAssemblyCache) continue;
+
+                var types = assembly.GetTypes();
+
+                handlers.AddRange(types.Where(isValidHandler));
+                filters.AddRange(types.Where(isValidFilter).ToList());
+            }
+
+            return new ScanResult { Handlers = handlers, Filters = filters };
+        }
+    }
+}

--- a/src/tinyweb.framework/AssemblyScanner/ScanResult.cs
+++ b/src/tinyweb.framework/AssemblyScanner/ScanResult.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace tinyweb.framework
+{
+    public class ScanResult
+    {
+        public IEnumerable<Type> Handlers { get; set; }
+        public IEnumerable<Type> Filters { get; set; }
+    }
+}

--- a/src/tinyweb.framework/Filters/FilterScanner/DefaultFilterScanner.cs
+++ b/src/tinyweb.framework/Filters/FilterScanner/DefaultFilterScanner.cs
@@ -6,20 +6,18 @@ namespace tinyweb.framework
 {
     public class DefaultFilterScanner : IFilterScanner
     {
-        public IEnumerable<FilterData> FindAll()
+        public IEnumerable<FilterData> FindAll(IEnumerable<Type> types)
         {
-            return findFilters();
+            return findFilters(types);
         }
 
-        private IEnumerable<FilterData> findFilters()
+        public Func<Type, bool> GetSearcher()
         {
-            var types = new List<Type>();
+            return t => t.Name.ToLower().EndsWith("filter");
+        }
 
-            AppDomain.CurrentDomain.GetAssemblies().ForEach(assembly =>
-            {
-                types.AddRange(assembly.GetTypes().Where(t => t.Name.ToLower().EndsWith("filter")));
-            });
-
+        private IEnumerable<FilterData> findFilters(IEnumerable<Type> types)
+        {
             var filters = new List<FilterData>();
 
             foreach (var type in types)

--- a/src/tinyweb.framework/Filters/FilterScanner/IFilterScanner.cs
+++ b/src/tinyweb.framework/Filters/FilterScanner/IFilterScanner.cs
@@ -1,9 +1,11 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
 namespace tinyweb.framework
 {
     public interface IFilterScanner
     {
-        IEnumerable<FilterData> FindAll();
+        IEnumerable<FilterData> FindAll(IEnumerable<Type> types);
+        Func<Type, bool> GetSearcher();
     }
 }

--- a/src/tinyweb.framework/Handlers/HandlerFactory/ActivatorHandlerFactory.cs
+++ b/src/tinyweb.framework/Handlers/HandlerFactory/ActivatorHandlerFactory.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace tinyweb.framework
+{
+    public class ActivatorHandlerFactory : IHandlerFactory
+    {
+        public object Create(HandlerData handlerData)
+        {
+            return Activator.CreateInstance(handlerData.Type);
+        }
+    }
+}

--- a/src/tinyweb.framework/Handlers/HandlerFactory/HandlerFactory.cs
+++ b/src/tinyweb.framework/Handlers/HandlerFactory/HandlerFactory.cs
@@ -2,7 +2,7 @@
 {
     public static class HandlerFactory
     {
-        static IHandlerFactory factory = new DefaultHandlerFactory();
+        static IHandlerFactory factory = new ActivatorHandlerFactory();
 
         public static IHandlerFactory Current
         {

--- a/src/tinyweb.framework/Handlers/HandlerFactory/StructureMapHandlerFactory.cs
+++ b/src/tinyweb.framework/Handlers/HandlerFactory/StructureMapHandlerFactory.cs
@@ -2,7 +2,7 @@
 
 namespace tinyweb.framework
 {
-    public class DefaultHandlerFactory : IHandlerFactory
+    public class StructureMapHandlerFactory : IHandlerFactory
     {
         public object Create(HandlerData handlerData)
         {

--- a/src/tinyweb.framework/Handlers/HandlerScanner/DefaultHandlerScanner.cs
+++ b/src/tinyweb.framework/Handlers/HandlerScanner/DefaultHandlerScanner.cs
@@ -97,10 +97,10 @@ namespace tinyweb.framework
 
         private string addHandlerAreaToRouteUriIfRegistered(Type handlerType, string routeUri)
         {
-            var handlerNamespace = handlerType.Namespace ?? "";
+            var handlerNamespace = handlerType.Namespace ?? string.Empty;
             var handlerArea = Tinyweb.Areas.ContainsKey(handlerNamespace) ? Tinyweb.Areas[handlerNamespace] : null;
 
-            if (string.IsNullOrEmpty(handlerArea) || handlerArea.Equals(routeUri))
+            if (handlerArea.IsEmpty() || handlerArea == routeUri)
             {
                 return routeUri;
             }

--- a/src/tinyweb.framework/Handlers/HandlerScanner/IHandlerScanner.cs
+++ b/src/tinyweb.framework/Handlers/HandlerScanner/IHandlerScanner.cs
@@ -1,9 +1,11 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
 namespace tinyweb.framework
 {
     public interface IHandlerScanner
     {
-        IEnumerable<HandlerData> FindAll();
+        IEnumerable<HandlerData> FindAll(IEnumerable<Type> types);
+        Func<Type, bool> GetSearcher();
     }
 }

--- a/src/tinyweb.framework/Init/Tinyweb.cs
+++ b/src/tinyweb.framework/Init/Tinyweb.cs
@@ -25,10 +25,16 @@ namespace tinyweb.framework
 
         public static int Init(params Registry[] registries)
         {
-            ObjectFactory.Initialize(x => registries.ForEach(x.AddRegistry));
+            if (registries.Any())
+            {
+                ObjectFactory.Initialize(x => registries.ForEach(x.AddRegistry));
+                HandlerFactory.SetHandlerFactory(new StructureMapHandlerFactory());
+            }
 
-            Filters = FilterScanner.Current.FindAll();
-            Handlers = HandlerScanner.Current.FindAll();
+            var scanResult = AssemblyScanner.FindHandlersAndFilters(HandlerScanner.Current.GetSearcher(), FilterScanner.Current.GetSearcher());
+
+            Handlers = HandlerScanner.Current.FindAll(scanResult.Handlers);
+            Filters = FilterScanner.Current.FindAll(scanResult.Filters);
             Handlers.ForEach(addRoute);
 
             return Handlers.Count();

--- a/src/tinyweb.framework/Init/Tinyweb.cs
+++ b/src/tinyweb.framework/Init/Tinyweb.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -37,7 +36,7 @@ namespace tinyweb.framework
 
         public static void RegisterArea(string area, string areaNamespace)
         {
-            Areas.Add(areaNamespace, area);
+            Areas.Add(areaNamespace, area.ToLower());
         }
 
         public static string WhatHaveIGot()

--- a/src/tinyweb.framework/tinyweb.framework.csproj
+++ b/src/tinyweb.framework/tinyweb.framework.csproj
@@ -61,6 +61,7 @@
     <Compile Include="Filters\FilterInvoker\DefaultFilterInvoker.cs" />
     <Compile Include="Filters\FilterInvoker\FilterInvoker.cs" />
     <Compile Include="Filters\FilterInvoker\IFilterInvoker.cs" />
+    <Compile Include="Handlers\HandlerFactory\ActivatorHandlerFactory.cs" />
     <Compile Include="Handlers\HandlerInvoker\ExecutionResult.cs" />
     <Compile Include="Handlers\HandlerResult\Context\RouteValues.cs" />
     <Compile Include="Handlers\HandlerResult\Context\IRouteValues.cs" />
@@ -77,6 +78,8 @@
     <Compile Include="Handlers\HandlerResult\XmlResult.cs" />
     <Compile Include="Handlers\HandlerResult\RedirectResult.cs" />
     <Compile Include="Handlers\HandlerResult\Factory\Result.cs" />
+    <Compile Include="AssemblyScanner\AssemblyScanner.cs" />
+    <Compile Include="AssemblyScanner\ScanResult.cs" />
     <Compile Include="Helpers\FakeApplicationPathProvider.cs" />
     <Compile Include="Helpers\IApplicationPathProvider.cs" />
     <Compile Include="Helpers\RealApplicationPathProvider.cs" />
@@ -89,7 +92,7 @@
     <Compile Include="Init\Tinyweb.cs" />
     <Compile Include="Handlers\HandlerInvoker\HttpVerb.cs" />
     <Compile Include="Exceptions\NoParameterlessConstructor.cs" />
-    <Compile Include="Handlers\HandlerFactory\DefaultHandlerFactory.cs" />
+    <Compile Include="Handlers\HandlerFactory\StructureMapHandlerFactory.cs" />
     <Compile Include="Handlers\HandlerFactory\HandlerFactory.cs" />
     <Compile Include="Init\HttpHandler.cs" />
     <Compile Include="Init\RouteHandler.cs" />

--- a/src/tinyweb.viewengine.razor/RazorCompiler.cs
+++ b/src/tinyweb.viewengine.razor/RazorCompiler.cs
@@ -5,6 +5,7 @@ using System.Collections.Concurrent;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
+using System.Web;
 using System.Web.Configuration;
 using System.Web.Razor;
 using System.Web.Razor.Generator;
@@ -54,12 +55,21 @@ namespace tinyweb.viewengine.razor
             if (!cache.TryGetValue(key, out type))
             {
                 type = GetCompiledType<T>(File.ReadAllText(path));
-                cache[key] = type;
+
+                if (CachingIsEnabled())
+                {
+                    cache[key] = type;
+                }
             }
 
             var instance = (TemplateBase<T>)Activator.CreateInstance(type);
             instance.Path = path;
             return instance;
+        }
+
+        private static bool CachingIsEnabled()
+        {
+            return !HttpContext.Current.IsDebuggingEnabled;
         }
 
         //used to render the master

--- a/src/tinyweb.viewengine.spark/SparkCompiler.cs
+++ b/src/tinyweb.viewengine.spark/SparkCompiler.cs
@@ -2,6 +2,7 @@
 using System.Collections.Concurrent;
 using System.Configuration;
 using System.IO;
+using System.Web;
 using Spark;
 using Spark.FileSystem;
 
@@ -29,7 +30,7 @@ namespace tinyweb.viewengine.spark
             var output = new StringWriter();
             view.RenderView(output);
             sparkEngine.ReleaseInstance(view);
-            
+
             return output.ToString();
         }
 
@@ -74,7 +75,11 @@ namespace tinyweb.viewengine.spark
             if (!cache.ContainsKey(key))
             {
                 entry = sparkEngine.CreateEntry(descriptor);
-                cache[key] = entry;
+
+                if (cachingIsEnabled())
+                {
+                    cache[key] = entry;
+                }
             }
             else
             {
@@ -82,6 +87,11 @@ namespace tinyweb.viewengine.spark
             }
 
             return entry;
+        }
+
+        private static bool cachingIsEnabled()
+        {
+            return !HttpContext.Current.IsDebuggingEnabled;
         }
     }
 }


### PR DESCRIPTION
Quick change to control view caching based on whether the site is setup for debugging or not:

<system.web>
    <compilation debug="true" targetFramework="4.0" />
</system.web>

In a production scenario the "debug" attribute is (should be) set to false (or removed entirely) in which case views will be cached for the best performance. During the tweak/reload development cycle they will be recompiled each time instead of having to restart the development web server to see your changes.
