### PR TITLE
Spark support for HTML method

### DIFF
--- a/src/tinyweb.viewengine.spark/SparkView.cs
+++ b/src/tinyweb.viewengine.spark/SparkView.cs
@@ -10,7 +10,12 @@ namespace tinyweb.viewengine.spark
         public string H(object value)
         {
             return HttpUtility.HtmlEncode(value.ToString());
-        } 
+        }
+
+        public string HTML(object value)
+        {
+            return value.ToString();
+        }
     }
 
     public abstract class SparkView : AbstractSparkView


### PR DESCRIPTION
One more - just stumbled across this while trying to use a macro in one of my views - turns out Spark is dependent on a method called "HTML" being there for writing out raw HTML content.

Thanks!
Matt
